### PR TITLE
Fix osx flags

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pyopencl" %}
 {% set version = "2018.2.2" %}
-{% set build_number = 1001 %}
+{% set build_number = 1002 %}
 {% set sha256 = "419375fb794d97f9bd46f0dc24ce83b5cc83d316771ba82fac80de8bf883dcdc" %}
 
 package:
@@ -11,6 +11,8 @@ source:
     fn: {{ name }}-{{ version }}.tar.gz
     url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
     sha256: {{ sha256 }}
+    patches:
+        - osx_flags.diff
 
 build:
     number: {{ build_number }}

--- a/recipe/osx_flags.diff
+++ b/recipe/osx_flags.diff
@@ -1,0 +1,37 @@
+diff --git a/setup.py b/setup.py
+index f017021..f71ee21 100644
+--- a/setup.py
++++ b/setup.py
+@@ -45,30 +45,8 @@ def get_config_schema():
+             ]
+ 
+     if 'darwin' in sys.platform:
+-        import platform
+-        osx_ver, _, _ = platform.mac_ver()
+-        osx_ver = '.'.join(osx_ver.split('.')[:2])
+-
+-        sysroot_paths = [
+-                "/Applications/Xcode.app/Contents/Developer/Platforms/"
+-                "MacOSX.platform/Developer/SDKs/MacOSX%s.sdk" % osx_ver,
+-                "/Developer/SDKs/MacOSX%s.sdk" % osx_ver
+-                ]
+-
+-        default_libs = []
+-        default_cxxflags = default_cxxflags + [
+-                '-stdlib=libc++', '-mmacosx-version-min=10.7',
+-                '-arch', 'i386', '-arch', 'x86_64'
+-                ]
+-
+-        from os.path import isdir
+-        for srp in sysroot_paths:
+-            if isdir(srp):
+-                default_cxxflags.extend(['-isysroot', srp])
+-                break
+-
+-        default_ldflags = default_cxxflags[:] + ["-Wl,-framework,OpenCL"]
+-
++        default_libs = ["OpenCL"]
++        default_ldflags = []
+     else:
+         default_libs = ["OpenCL"]
+         if "linux" in sys.platform:


### PR DESCRIPTION
There were few issues with the flags.

1. It was linking in the khronos icd loader and the apple framework
2. It was using the latest sdk, but we need the sdk that conda-forge is defaulting to
3. `-mmacosx-version-min=10.7` is too old and uses libstdc++ instead of libc++