### PR TITLE
rebuild for latest khronos-opencl-icd-loader

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pyopencl" %}
 {% set version = "2021.2.6" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% set sha256 = "df208546d28a3274ba7b554d50643ed1e393b8f3f75a43b24b83d3ee76597587" %}
 
 package:


### PR DESCRIPTION
previous builds of the loader was creating a temp file, but
not deleting it which meant that the temp file was packaged in
pyopencl. rebuilding should avoid the temp file
